### PR TITLE
Pin Anaconda to 3.7, use `ome=True` when writing TIFF images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get -qq update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh \
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-Linux-x86_64.sh -O /tmp/miniconda.sh \
     && /bin/bash /tmp/miniconda.sh -b -p /opt/conda \
     && rm /tmp/miniconda.sh
 ENV PATH /opt/conda/bin:$PATH
@@ -20,6 +20,8 @@ ENV PATH /opt/conda/bin:$PATH
 RUN mkdir /output && chmod -R a+rwx /output
 
 # update base environment from yaml file
+RUN conda install -n base conda-libmamba-solver \
+  && conda config --set solver libmamba
 COPY environment.yml /tmp/
 RUN conda env update -f /tmp/environment.yml \
     && echo "source activate base" > ~/.bashrc \

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -93,7 +93,7 @@ def write_stack_to_file(out_path: str, stack, mismatch: float):
     ome_meta = fill_in_ome_meta_template(stack.shape[-2], stack.shape[-1], dtype, mismatch)
     stack_shape = stack.shape
     new_stack_shape = [stack_shape[0], 1, stack_shape[1], stack_shape[2]]
-    with tif.TiffWriter(out_path, bigtiff=True, shaped=False) as TW:
+    with tif.TiffWriter(out_path, bigtiff=True, ome=True) as TW:
         TW.write(
             stack.reshape(new_stack_shape).astype(dtype),
             contiguous=True,


### PR DESCRIPTION
This allows building the Docker image with existing package versions (rather than fighting with CUDA compatibility), and writes images in a format readable with current `tifffile` also.