### PR TITLE
allow_cell_only option

### DIFF
--- a/bin/img_proc/match_masks.py
+++ b/bin/img_proc/match_masks.py
@@ -138,6 +138,11 @@ def get_matched_masks(mask_stack: Image, do_mismatch_repair: bool) -> Tuple[Imag
             nuclear_search_num = np.unique(
                 list(map(lambda x: nuclear_mask[tuple(x)], current_cell_coords))
             )
+            if len(nuclear_search_num) == 0 :
+                print("No nucleus found for cell ", i)
+                cell_matched_list.append(cell_coords[i])
+                cell_matched_index_list.append(i)
+                continue
             best_mismatch_fraction = 1
             whole_cell_best = []
             for j in nuclear_search_num:

--- a/bin/img_proc/match_masks.py
+++ b/bin/img_proc/match_masks.py
@@ -110,7 +110,7 @@ def get_fraction_matched_cells(
     return fraction_matched_cells
 
 
-def get_matched_masks(mask_stack: Image, do_mismatch_repair: bool) -> Tuple[Image, float]:
+def get_matched_masks(mask_stack: Image, do_mismatch_repair: bool, allow_cells_only = False) -> Tuple[Image, float]:
     """
     returns masks with matched cells and nuclei
     """
@@ -138,7 +138,8 @@ def get_matched_masks(mask_stack: Image, do_mismatch_repair: bool) -> Tuple[Imag
             nuclear_search_num = np.unique(
                 list(map(lambda x: nuclear_mask[tuple(x)], current_cell_coords))
             )
-            if len(nuclear_search_num) == 0 :
+            #If allow_only_cells option then allow cells without nucleus
+            if allow_cells_only and len(nuclear_search_num) == 0 :
                 print("No nucleus overlap for cell ", i)
                 cell_matched_list.append(cell_coords[i])
                 cell_matched_index_list.append(i)
@@ -168,7 +169,8 @@ def get_matched_masks(mask_stack: Image, do_mismatch_repair: bool) -> Tuple[Imag
                 nucleus_matched_list.append(nucleus_best)
                 cell_matched_index_list.append(i_ind)
                 nucleus_matched_index_list.append(j_ind)
-            else:
+            elif allow_cells_only:
+                # If allow_only_cells option then allow cells without nucleus
                 print("No nucleus found for cell ", i)
                 cell_matched_list.append(cell_coords[i])
                 cell_matched_index_list.append(i)

--- a/bin/img_proc/match_masks.py
+++ b/bin/img_proc/match_masks.py
@@ -139,7 +139,7 @@ def get_matched_masks(mask_stack: Image, do_mismatch_repair: bool) -> Tuple[Imag
                 list(map(lambda x: nuclear_mask[tuple(x)], current_cell_coords))
             )
             if len(nuclear_search_num) == 0 :
-                print("No nucleus found for cell ", i)
+                print("No nucleus overlap for cell ", i)
                 cell_matched_list.append(cell_coords[i])
                 cell_matched_index_list.append(i)
                 continue
@@ -168,6 +168,11 @@ def get_matched_masks(mask_stack: Image, do_mismatch_repair: bool) -> Tuple[Imag
                 nucleus_matched_list.append(nucleus_best)
                 cell_matched_index_list.append(i_ind)
                 nucleus_matched_index_list.append(j_ind)
+            else:
+                print("No nucleus found for cell ", i)
+                cell_matched_list.append(cell_coords[i])
+                cell_matched_index_list.append(i)
+
 
     del cell_coords
     del nucleus_coords

--- a/bin/main.py
+++ b/bin/main.py
@@ -65,7 +65,7 @@ def remove_gpus_if_more_than_imgs(
 
 
 def run_segmentation(
-    method: str, dataset_dir: Path, gpu_ids: List[int], segm_channels: Tuple[str]
+    method: str, dataset_dir: Path, gpu_ids: List[int], segm_channels: Tuple[str], allow_cells_only=False
 ):
     self_location = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
     script_path = osp.join(self_location, "segment.py")
@@ -77,6 +77,7 @@ def run_segmentation(
         + " --gpu_id {gpu_id} "
         + ' --gpus "{gpus}" '
         + ' --segm_channels "{segm_channels}" '
+        + ' --allow_cells_only "{allow_cells_only}" '
     )
 
     processes = []
@@ -97,7 +98,7 @@ def run_segmentation(
             raise ChildProcessError(msg)
 
 
-def main(method: str, dataset_dir: Path, gpus: str):
+def main(method: str, dataset_dir: Path, gpus: str, allow_cells_only=False):
     start = datetime.now()
     # batch_size can't be larger for celldive + deepcell because all images have different shapes
     batch_size = 1
@@ -109,7 +110,7 @@ def main(method: str, dataset_dir: Path, gpus: str):
 
     gpu_ids = get_allowed_gpu_ids(gpus)
     gpu_ids = remove_gpus_if_more_than_imgs(dataset_dir, gpu_ids, segm_channels)
-    run_segmentation(method, dataset_dir, gpu_ids, segm_channels)
+    run_segmentation(method, dataset_dir, gpu_ids, segm_channels, allow_cells_only)
     finish = datetime.now()
     print("Finished segmentation pipeline", str(finish))
     print("Time elapsed ", str(finish - start))
@@ -122,6 +123,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--gpus", type=str, default="all", help="comma separated ids of gpus to use, e.g. 0,1,2"
     )
+    parser.add_argument("--allow_cells_only", type=bool, default=False, help="allow cells without nucleus")
     args = parser.parse_args()
 
-    main(args.method, args.dataset_dir, args.gpus)
+    main(args.method, args.dataset_dir, args.gpus, args.allow_cells_only)

--- a/bin/main.py
+++ b/bin/main.py
@@ -69,6 +69,10 @@ def run_segmentation(
 ):
     self_location = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
     script_path = osp.join(self_location, "segment.py")
+    if allow_cells_only:
+        cells_str = "--allow_cells_only"
+    else:
+        cells_str = ""
     cmd_template = (
         "CUDA_VISIBLE_DEVICES={gpu_id} "
         + ' python "{script_path}" '
@@ -77,7 +81,7 @@ def run_segmentation(
         + " --gpu_id {gpu_id} "
         + ' --gpus "{gpus}" '
         + ' --segm_channels "{segm_channels}" '
-        + ' --allow_cells_only "{allow_cells_only}" '
+        + cells_str
     )
 
     processes = []
@@ -89,7 +93,6 @@ def run_segmentation(
             gpus=",".join(str(i) for i in gpu_ids),
             dataset_dir=path_to_str(dataset_dir),
             segm_channels=",".join(segm_channels),
-            allow_cells_only=allow_cells_only
         )
         processes.append(Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE, universal_newlines=True))
     for proc in processes:

--- a/bin/main.py
+++ b/bin/main.py
@@ -89,6 +89,7 @@ def run_segmentation(
             gpus=",".join(str(i) for i in gpu_ids),
             dataset_dir=path_to_str(dataset_dir),
             segm_channels=",".join(segm_channels),
+            allow_cells_only=allow_cells_only
         )
         processes.append(Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE, universal_newlines=True))
     for proc in processes:

--- a/bin/segment.py
+++ b/bin/segment.py
@@ -40,6 +40,7 @@ def save_masks(
             axis=0,
         )
         st = datetime.now()
+        write_stack_to_file(path_to_str(out_dir / "test"), mask_stack,0)
         print("Started matching cell and nuclei", str(st))
         matched_stack, fraction_matched = get_matched_masks(mask_stack, True)
         fin = datetime.now()

--- a/bin/segment.py
+++ b/bin/segment.py
@@ -40,7 +40,7 @@ def save_masks(
             axis=0,
         )
         st = datetime.now()
-        write_stack_to_file(path_to_str(out_dir / "test"), mask_stack,0)
+        #write_stack_to_file(path_to_str(out_dir / "test"), mask_stack,0)
         print("Started matching cell and nuclei", str(st))
         matched_stack, fraction_matched = get_matched_masks(mask_stack, True)
         fin = datetime.now()


### PR DESCRIPTION
This adds an --allow_cell_only option to the segmentations with modifies the behavoir of match_masks to allow cells without a nucleus. This feature has been requested for some data sources.